### PR TITLE
Prevent stack trace collection from blocking if read blocks after select

### DIFF
--- a/threadstacks/signal_handler.cc
+++ b/threadstacks/signal_handler.cc
@@ -478,7 +478,8 @@ auto StackTraceCollector::Collect(std::string* error) -> std::vector<Result> {
 std::string StackTraceCollector::ToPrettyString(const std::vector<Result>& r) {
   std::ostringstream ss;
   for (const auto& e : r) {
-    if (e.empty()) {
+    if (e.tids.empty()) {
+      ss << "No Threads" << std::endl;
       continue;
     }
     ss << "Threads: ";


### PR DESCRIPTION
As per https://stackoverflow.com/questions/5351994/will-read-ever-block-after-select, a
`read` can block on a file descriptor even if a previous `select` on the `fd` returned with `FD_ISSET` being true for the `fd`.
Under such a scenario, the thread collecting stacktraces can block forever.